### PR TITLE
Created Sprite and Entity class

### DIFF
--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -5,20 +5,22 @@ using namespace System;
 ref class Entity : public Sprite {
 protected:
   String^ name;
-  int x, y;
   bool movable;
   float health;
   float damagePoints;
 public:
-  Entity(String^ name, Point pos, bool movable, float health, float damagePoints) {
+  Entity(short nCols, short nRows, bool animatable, String^ name, Point pos, bool movable, float health, float damagePoints)
+    :Sprite(nCols, nRows, animatable) {
     this->name = name;
-    this->x = pos.X;
-    this->y = pos.Y;
+    this->drawingArea.X = pos.X;
+    this->drawingArea.Y = pos.Y;
     this->movable = movable;
     this->health = health;
     this->damagePoints = damagePoints;
   }
-  ~Entity() {}
+  ~Entity() {
+    delete this->name;
+  }
   bool IsMovable() {
     return this->movable;
   }
@@ -32,19 +34,11 @@ public:
     return this->damagePoints;
   }
   bool Collision(Entity object) {
-    //Debe ser drawingArea protected
-    //return this->drawingArea.IntersectsWith(object.drawingArea);
+    return this->drawingArea.IntersectsWith(object.drawingArea);
   }
   virtual void Move(short dx, short dy) {
-    //x y no están enlazados con la posicion de drawingArea
-    this->x += dx;
-    this->y += dy;
-    /*
-    * Una posibilidad podría hacer esto
     this->drawingArea.X += dx;
     this->drawingArea.Y += dy;
-    * O también colocar el x y en sprite
-    */
   }
 };
 

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -1,1 +1,50 @@
 #pragma once
+#include "Sprite.h"
+using namespace System;
+
+ref class Entity : public Sprite {
+protected:
+  String^ name;
+  int x, y;
+  bool movable;
+  float health;
+  float damagePoints;
+public:
+  Entity(String^ name, Point pos, bool movable, float health, float damagePoints) {
+    this->name = name;
+    this->x = pos.X;
+    this->y = pos.Y;
+    this->movable = movable;
+    this->health = health;
+    this->damagePoints = damagePoints;
+  }
+  ~Entity() {}
+  bool IsMovable() {
+    return this->movable;
+  }
+  float GetHealth() {
+    return this->health;
+  }
+  void SetHealth(float health) {
+    this->health = health;
+  }
+  float GetDamagePoint() {
+    return this->damagePoints;
+  }
+  bool Collision(Entity object) {
+    //Debe ser drawingArea protected
+    //return this->drawingArea.IntersectsWith(object.drawingArea);
+  }
+  virtual void Move(short dx, short dy) {
+    //x y no están enlazados con la posicion de drawingArea
+    this->x += dx;
+    this->y += dy;
+    /*
+    * Una posibilidad podría hacer esto
+    this->drawingArea.X += dx;
+    this->drawingArea.Y += dy;
+    * O también colocar el x y en sprite
+    */
+  }
+};
+

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -13,8 +13,7 @@ public:
   Entity(short nCols, short nRows, bool animatable, String^ name, Point pos, bool movable, float health, float damagePoints)
     :Sprite(nCols, nRows, animatable) {
     this->name = name;
-    this->drawingArea.X = pos.X;
-    this->drawingArea.Y = pos.Y;
+    this->drawingArea.Location = pos;
     this->movable = movable;
     this->health = health;
     this->damagePoints = damagePoints;

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -2,6 +2,7 @@
 #include "Sprite.h"
 using namespace System;
 
+//Entity publicly inheriting Sprite
 ref class Entity : public Sprite {
 protected:
   String^ name;
@@ -18,9 +19,7 @@ public:
     this->health = health;
     this->damagePoints = damagePoints;
   }
-  ~Entity() {
-    delete this->name;
-  }
+  ~Entity() {}
   bool IsMovable() {
     return this->movable;
   }
@@ -34,6 +33,7 @@ public:
     return this->damagePoints;
   }
   bool Collision(Entity object) {
+    //Collision needs the drawingArea of another Entity to return if the object collides or not
     return this->drawingArea.IntersectsWith(object.drawingArea);
   }
   virtual void Move(short dx, short dy) {

--- a/ZionEscape/Sprite.h
+++ b/ZionEscape/Sprite.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/ZionEscape/Sprite.h
+++ b/ZionEscape/Sprite.h
@@ -5,13 +5,23 @@ using namespace System::Drawing;
 ref class Sprite {
   Bitmap^ image;
   short col, row, nCols, nRows;
+  bool animatable;
+protected:
   Rectangle drawingArea;
 public:
+  Sprite(short nCols, short nRows, bool animatable) {
+    this->nCols = nCols;
+    this->nRows = nRows;
+    this->animatable = animatable;
+  }
   void SetPosition(Point point) {
     this->drawingArea.Location = point;
   }
   Point GetPosition() {
     return drawingArea.Location;
+  }
+  bool GetAnimatable() {
+    return animatable;
   }
   void SetCol(short index) {
     this->col = index;
@@ -21,7 +31,7 @@ public:
   }
   void Draw(Graphics^ world) {
     world->DrawImage(image, this->drawingArea, this->GetCrop(), GraphicsUnit::Pixel);
-    //Se debe controlar en cuáles casos animar el Sprite. Tanto por si está en movimiento o por si se trata de algún Obstáculo.
+    if (!this->animatable) return;
     this->col = (this->col + 1) % nCols;
   }
   Rectangle GetCrop() {
@@ -32,5 +42,4 @@ public:
 
     return Rectangle(x, y, width, height);
   }
-
 };

--- a/ZionEscape/Sprite.h
+++ b/ZionEscape/Sprite.h
@@ -1,1 +1,36 @@
 #pragma once
+using namespace System;
+using namespace System::Drawing;
+
+ref class Sprite {
+  Bitmap^ image;
+  short col, row, nCols, nRows;
+  Rectangle drawingArea;
+public:
+  void SetPosition(Point point) {
+    this->drawingArea.Location = point;
+  }
+  Point GetPosition() {
+    return drawingArea.Location;
+  }
+  void SetCol(short index) {
+    this->col = index;
+  }
+  void SetRow(short index) {
+    this->row = index;
+  }
+  void Draw(Graphics^ world) {
+    world->DrawImage(image, this->drawingArea, this->GetCrop(), GraphicsUnit::Pixel);
+    //Se debe controlar en cuáles casos animar el Sprite. Tanto por si está en movimiento o por si se trata de algún Obstáculo.
+    this->col = (this->col + 1) % nCols;
+  }
+  Rectangle GetCrop() {
+    short width = this->image->Width / this->nCols;
+    short height = this->image->Height / this->nRows;
+    short x = this->col * width;
+    short y = this->row * height;
+
+    return Rectangle(x, y, width, height);
+  }
+
+};

--- a/ZionEscape/Sprite.h
+++ b/ZionEscape/Sprite.h
@@ -31,6 +31,7 @@ public:
   }
   void Draw(Graphics^ world) {
     world->DrawImage(image, this->drawingArea, this->GetCrop(), GraphicsUnit::Pixel);
+    // If the bool animatable is false, the col won't be added by 1. Because of this, it won't be animated
     if (!this->animatable) return;
     this->col = (this->col + 1) % nCols;
   }

--- a/ZionEscape/Sprite.h
+++ b/ZionEscape/Sprite.h
@@ -30,12 +30,12 @@ public:
     this->row = index;
   }
   void Draw(Graphics^ world) {
-    world->DrawImage(image, this->drawingArea, this->GetCrop(), GraphicsUnit::Pixel);
+    world->DrawImage(image, this->drawingArea, this->GetCropArea(), GraphicsUnit::Pixel);
     // If the bool animatable is false, the col won't be added by 1. Because of this, it won't be animated
     if (!this->animatable) return;
     this->col = (this->col + 1) % nCols;
   }
-  Rectangle GetCrop() {
+  Rectangle GetCropArea() {
     short width = this->image->Width / this->nCols;
     short height = this->image->Height / this->nRows;
     short x = this->col * width;

--- a/ZionEscape/ZionEscape.vcxproj
+++ b/ZionEscape/ZionEscape.vcxproj
@@ -169,11 +169,13 @@
     <ResourceCompile Include="app.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Entity.h" />
     <ClInclude Include="MainActivity.h">
       <FileType>CppForm</FileType>
     </ClInclude>
     <ClInclude Include="pch.h" />
     <ClInclude Include="Resource.h" />
+    <ClInclude Include="Sprite.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />

--- a/ZionEscape/ZionEscape.vcxproj.filters
+++ b/ZionEscape/ZionEscape.vcxproj.filters
@@ -29,6 +29,12 @@
     <ClInclude Include="MainActivity.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Sprite.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Entity.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ZionEscape.cpp">


### PR DESCRIPTION
<!-- Español -->

### Qué es lo que hace

Se añaden las clases `Sprite` y `Entity` con sus respectivos métodos y atributos. 

### Por qué es necesario

Es necesario para poder añadir las demás clases faltantes que heredan de `Entity`, tales como `Player`, `Obstacle` o `NPC`.

### Issue(s) o PR(s) relacionados

Fixes #3 

### Contexto Adicional

Comentarios han sido añadidos. Si encuentran necesario alguno otro, notifíquenmelo.
