### PR TITLE
Added optional map generator seed

### DIFF
--- a/ZionEscape/Game.h
+++ b/ZionEscape/Game.h
@@ -13,12 +13,16 @@ public:
     this->map = gcnew Map();
   }
 
-  void Generation(Graphics^ g) {
-    this->map->MapGeneration(g);
+  void StartGeneration(Graphics^ g) {
+    this->map->StartGeneration(g);
   }
 
   bool IsGenerated() {
-    return this->map->GetGenerated();
+    return this->map->IsGenerated();
+  }
+
+  int GetMapSeed() {
+    return this->map->GetSeed();
   }
 };
 

--- a/ZionEscape/MainActivity.h
+++ b/ZionEscape/MainActivity.h
@@ -15,6 +15,7 @@ namespace ZionEscape {
   using namespace System::Collections;
   using namespace System::Data;
   using namespace System::Windows::Forms;
+  using namespace System::Diagnostics;
 
   // Main Activity Form
   public ref class MainActivity : public Form {
@@ -104,7 +105,7 @@ namespace ZionEscape {
   private: void MainActivity_Paint(Object^ sender, PaintEventArgs^ e) {
     Graphics^ world = e->Graphics;
     world->DrawImage(this->background, Point(0, 0));
-    this->game->Generation(world);
+    this->game->StartGeneration(world);
     for each (NPC ^ npc in npcs) {
       npc->Draw(world);
     }
@@ -113,6 +114,12 @@ namespace ZionEscape {
   }
 
   private: void MainActivity_KeyDown(Object^ sender, KeyEventArgs^ e) {
+    // Temporary Map Seed Print
+    if (e->KeyCode == Keys::P) {
+      Debug::WriteLine("Seed: {0}", this->game->GetMapSeed());
+      return;
+    }
+
     if (!validKeys->Contains(e->KeyCode)) return;
 
     if (!keysPressed->Contains(e->KeyCode)) {

--- a/ZionEscape/Map.h
+++ b/ZionEscape/Map.h
@@ -11,14 +11,22 @@ using namespace System::Drawing;
 ref class Map {
   List<Scene^>^ scenes;
   Random^ rnd;
-  short maxScenes;
+  int seed;
+  int maxScenes;
   bool isGenerating;
   bool generated;
 
 public:
-  Map() {
-    this->rnd = gcnew Random();
-    this->maxScenes = rnd->Next(40, 50);
+  Map(): Map(40, 50, Environment::TickCount) {}
+
+  Map(int seed): Map(40, 50, seed) {}
+
+  Map(int min, int max): Map(min, max, Environment::TickCount) {}
+
+  Map(int min, int max, int seed) {
+    this->seed = seed;
+    this->rnd = gcnew Random(seed);
+    this->maxScenes = rnd->Next(min, max);
     this->Reboot();
   }
 
@@ -47,12 +55,12 @@ public:
     this->CreateScene(1, 1, 1, 1, Point(468, 312));
   }
 
-  void CreateScene(bool t, bool d, bool r, bool l, Point pos) {
-    this->scenes->Add(gcnew Scene(t, d, r, l, pos));
+  void CreateScene(bool up, bool down, bool left, bool right, Point pos) {
+    this->scenes->Add(gcnew Scene(up, down, left, right, pos));
     this->scenes[this->scenes->Count - 1]->CreateSpawner(pos);
   }
 
-  void MapGeneration(Graphics^ g) {
+  void StartGeneration(Graphics^ g) {
     //Generate new Scenes
     if (this->isGenerating) {
 
@@ -135,7 +143,7 @@ public:
               }
             }
             //Create a new scene
-            this->CreateScene(up, down, right, left, pos);
+            this->CreateScene(up, down, left, right, pos);
             //After the creation of the scene, delete the curSpawner
             this->scenes[curScene]->DeleteSpawner(curSpawner - 1);
           }
@@ -215,8 +223,12 @@ public:
     }
   }
 
-  bool GetGenerated() {
+  bool IsGenerated() {
     return this->generated;
+  }
+
+  int GetSeed() {
+    return this->seed;
   }
 };
 

--- a/ZionEscape/Scene.h
+++ b/ZionEscape/Scene.h
@@ -15,8 +15,9 @@ ref class Scene {
   bool up, down, right, left;
   List<SceneSpawner^>^ spawners;
   Rectangle drawingArea;
+
 public:
-  Scene(bool up, bool down, bool right, bool left, Point pos) {
+  Scene(bool up, bool down, bool left, bool right, Point pos) {
     this->bmpManager = BitmapManager::GetInstance();
     this->spawners = gcnew List<SceneSpawner^>;
     this->up = up;


### PR DESCRIPTION
### Qué es lo que hace

Permite asignar una semilla de generador el mapa para la creación de mapas 100% replicables.

### Uso

```cpp
int seed = 949631203;
Map^ map = gcnew Map(seed);
```

![image](https://user-images.githubusercontent.com/7624090/99573509-31b12380-29a4-11eb-8564-9f36a646c4c9.png)


### Por qué es necesario

Permitirá la replicación de problemas, así como la opción de jugar una partida en un mapa exactamente igual.
