### PR TITLE
Changed data type of velocity

### DIFF
--- a/ZionEscape/Ally.h
+++ b/ZionEscape/Ally.h
@@ -13,7 +13,7 @@ using namespace System::Drawing;
 ref class Ally : public NPC {
 public:
   Ally(Point pos)
-    : NPC(EntityType::Ally, pos, 2, 1.f, 0.f) {
+    : NPC(EntityType::Ally, pos, 2U, 1.f, 0.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\aliados\\aliado-bueno.png");
     this->SetImage(image, 4, 4);

--- a/ZionEscape/Assassin.h
+++ b/ZionEscape/Assassin.h
@@ -10,7 +10,7 @@
 ref class Assassin : public NPC {
 public:
   Assassin(Point pos)
-    : NPC(EntityType::Assassin, pos, 3, 3.f, 2.f) {
+    : NPC(EntityType::Assassin, pos, 3U, 3.f, 2.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\asesinos\\asesino.png");
     this->SetImage(image, 3, 4);

--- a/ZionEscape/Corrupt.h
+++ b/ZionEscape/Corrupt.h
@@ -10,7 +10,7 @@
 ref class Corrupt : public NPC {
 public:
   Corrupt(Point pos)
-    : NPC(EntityType::Corrupt, pos, 2, 5.f, 1.f) {
+    : NPC(EntityType::Corrupt, pos, 2U, 5.f, 1.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\corruptos\\corrupto.png");
     this->SetImage(image, 4, 4);

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -16,10 +16,10 @@ protected:
   bool movable;
   float healthPoints;
   float damagePoints;
-  int velocity;
+  unsigned short velocity;
 
 public:
-  Entity(EntityType entityType, Point pos, int velocity, float healthPoints, float damagePoints)
+  Entity(EntityType entityType, Point pos, unsigned short velocity, float healthPoints, float damagePoints)
     : Sprite(entityType != EntityType::Obstacle) {
     this->entityType = entityType;
     this->drawingArea.Location = pos;

--- a/ZionEscape/NPC.h
+++ b/ZionEscape/NPC.h
@@ -14,7 +14,7 @@ ref class NPC abstract : public Entity {
 public:
   List<Node^>^ path;
 
-  NPC(EntityType entityType, Point pos, int velocity, float healthPoints, float damagePoints)
+  NPC(EntityType entityType, Point pos, unsigned short velocity, float healthPoints, float damagePoints)
     : Entity(entityType, pos, velocity, healthPoints, damagePoints) {}
 
   bool HasEndedPath() {

--- a/ZionEscape/Player.h
+++ b/ZionEscape/Player.h
@@ -9,14 +9,14 @@
 ref class Player : public Entity {
 public:
   Player(Point pos)
-    : Entity(EntityType::Player, pos, 3, 10.f, 2.f) {
+    : Entity(EntityType::Player, pos, 3U, 10.f, 2.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\principal\\principal_m.png");
     this->SetImage(image, 4, 4);
   }
 
   Player(Bitmap^ image, short nCols, short nRows, Point pos)
-    : Entity(EntityType::Player, pos, 3, 10.f, 2.f) {
+    : Entity(EntityType::Player, pos, 3U, 10.f, 2.f) {
     this->SetImage(image, nCols, nRows);
   }
 


### PR DESCRIPTION
### Qué es lo que hace

Se ha cambiado el tipo de valor de velocity por unsigned short.

### Por qué es necesario

Porque un entero es demasiado considerando que la velocidad a usar es un número pequeño. Asimismo, la velocidad siempre es positiva.

### Issue(s) o PR(s) relacionados

Fixes #20 
