### PR TITLE
Fixed scene delete loop

### DIFF
--- a/ZionEscape/Scene.h
+++ b/ZionEscape/Scene.h
@@ -35,15 +35,11 @@ public:
     }
 
     if (spawners != nullptr) {
-      for each (KeyValuePair<Direction, SceneSpawner^> element in spawners)
-        delete element.Value;
       spawners->Clear();
       delete spawners;
     }
 
     if (neighbours != nullptr) {
-      for each (KeyValuePair<Direction, Scene^> element in neighbours)
-        delete element.Value;
       neighbours->Clear();
       delete neighbours;
     }


### PR DESCRIPTION
### Qué es lo que hace

Se solucionó el problema generado por un bucle de deletes en las escenas, al estar intentando borrarse entre vecinos infinitamente hasta llenar el `stack`.
