### PR TITLE
Fixed pathfinder

### DIFF
--- a/ZionEscape/Ally.h
+++ b/ZionEscape/Ally.h
@@ -13,7 +13,7 @@ using namespace System::Drawing;
 ref class Ally : public NPC {
 public:
   Ally(Point pos)
-    : NPC(EntityType::Ally, pos, 2U, 1.f, 0.f) {
+    : NPC(EntityType::Ally, pos, 3U, 1.f, 0.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\aliados\\aliado-bueno.png");
     this->SetImage(image, 4, 4);

--- a/ZionEscape/Assassin.h
+++ b/ZionEscape/Assassin.h
@@ -11,7 +11,7 @@ ref class Assassin : public NPC {
   short cooldown;
 public:
   Assassin(Point pos)
-    : NPC(EntityType::Assassin, pos, 3U, 3.f, 1.f) {
+    : NPC(EntityType::Assassin, pos, 5U, 3.f, 1.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
     Bitmap^ image = bmpManager->GetImage("assets\\sprites\\asesinos\\asesino.png");
     this->SetImage(image, 3, 4);

--- a/ZionEscape/Corrupt.h
+++ b/ZionEscape/Corrupt.h
@@ -4,11 +4,14 @@
 #define _CORRUPT_H_
 
 #include "NPC.h"
+#include "Ally.h"
 #include "Entity.h"
 #include "BitmapManager.h"
 
 ref class Corrupt : public NPC {
 public:
+  Ally^ tracking;
+
   Corrupt(Point pos)
     : NPC(EntityType::Corrupt, pos, 2U, 5.f, 1.f) {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
@@ -19,7 +22,7 @@ public:
 
   void ConvertToAlly() {
     BitmapManager^ bmpManager = BitmapManager::GetInstance();
-    Bitmap^ image = bmpManager->GetImage("assets\\sprites\\aliados\\aliado-malo.png");
+    Bitmap^ image = bmpManager->GetImage("assets\\sprites\\aliados\\aliado-corrupto.png");
     this->SetImage(image, 4, 4);
   }
 

--- a/ZionEscape/Entity.h
+++ b/ZionEscape/Entity.h
@@ -83,7 +83,7 @@ public:
     Move(direction, nullptr);
   }
 
-  virtual void Move(int deltaX, int deltaY) {
+  virtual void Move(int deltaX, int deltaY, Grid^ grid) {
     for each (Direction direction in GetDirectionFromDelta(deltaX, deltaY))
       Move(direction);
   }

--- a/ZionEscape/MainActivity.h
+++ b/ZionEscape/MainActivity.h
@@ -24,6 +24,7 @@ namespace ZionEscape {
     System::ComponentModel::IContainer^ components;
     System::Windows::Forms::Timer^ MovementTimer;
     System::Windows::Forms::Timer^ AnimationTimer;
+    System::Windows::Forms::Timer^ PathfinderTimer;
     // User-defined properties.
     UserInterface currentUI;
     Point prevMouseLoc;
@@ -55,19 +56,26 @@ namespace ZionEscape {
       this->components = (gcnew System::ComponentModel::Container());
       this->MovementTimer = (gcnew System::Windows::Forms::Timer(this->components));
       this->AnimationTimer = (gcnew System::Windows::Forms::Timer(this->components));
+      this->PathfinderTimer = (gcnew System::Windows::Forms::Timer(this->components));
       this->SuspendLayout();
       // 
       // MovementTimer
       // 
-      this->MovementTimer->Enabled = true;
+      this->MovementTimer->Enabled = false;
       this->MovementTimer->Interval = 20;
       this->MovementTimer->Tick += gcnew System::EventHandler(this, &MainActivity::MovementTimer_Tick);
       // 
       // AnimationTimer
       // 
-      this->AnimationTimer->Enabled = true;
+      this->AnimationTimer->Enabled = false;
       this->AnimationTimer->Interval = 80;
       this->AnimationTimer->Tick += gcnew System::EventHandler(this, &MainActivity::AnimationTimer_Tick);
+      // 
+      // PathfinderTimer
+      // 
+      this->PathfinderTimer->Enabled = false;
+      this->PathfinderTimer->Interval = 200;
+      this->PathfinderTimer->Tick += gcnew System::EventHandler(this, &MainActivity::PathfinderTimer_Tick);
       // 
       // MainActivity
       // 
@@ -110,6 +118,10 @@ namespace ZionEscape {
         AnimationTimer->Start();
       }
 
+      if (!PathfinderTimer->Enabled) {
+        PathfinderTimer->Start();
+      }
+
       game->Paint(world);
     } else if (currentUI == UserInterface::Pause) {
       UI::DrawPause(world, mouseLoc);
@@ -135,6 +147,7 @@ namespace ZionEscape {
       currentUI = UserInterface::InGame;
       MovementTimer->Start();
       AnimationTimer->Start();
+      PathfinderTimer->Start();
       Invalidate();
       return;
     }
@@ -144,6 +157,7 @@ namespace ZionEscape {
         currentUI = UserInterface::Pause;
         MovementTimer->Stop();
         AnimationTimer->Stop();
+        PathfinderTimer->Stop();
         Invalidate();
         return;
       }
@@ -185,9 +199,15 @@ namespace ZionEscape {
 
     Invalidate();
   }
+
   private: void MainActivity_MouseClick(Object^ sender, MouseEventArgs^ e) {
     currentUI = UI::ClickEvent(e->Location, currentUI);
     Invalidate();
+  }
+
+  private: void PathfinderTimer_Tick(Object^ sender, EventArgs^ e) {
+    if (game != nullptr)
+      game->ResetPathfinders();
   }
 };
 }

--- a/ZionEscape/MainActivity.h
+++ b/ZionEscape/MainActivity.h
@@ -37,6 +37,8 @@ namespace ZionEscape {
 
       // User-defined code.
       currentUI = UserInterface::MainMenu;
+      // Set custom cursor
+      Cursor = gcnew System::Windows::Forms::Cursor("assets\\sprites\\misc\\cursor.ico");
     }
 
   protected:
@@ -76,7 +78,6 @@ namespace ZionEscape {
       this->Margin = System::Windows::Forms::Padding(4);
       this->Name = L"MainActivity";
       this->Text = L"Zion Escape";
-      this->Cursor = gcnew System::Windows::Forms::Cursor("assets\\sprites\\misc\\cursor.ico");
       this->Paint += gcnew System::Windows::Forms::PaintEventHandler(this, &MainActivity::MainActivity_Paint);
       this->KeyDown += gcnew System::Windows::Forms::KeyEventHandler(this, &MainActivity::MainActivity_KeyDown);
       this->KeyUp += gcnew System::Windows::Forms::KeyEventHandler(this, &MainActivity::MainActivity_KeyUp);

--- a/ZionEscape/MainActivity.resx
+++ b/ZionEscape/MainActivity.resx
@@ -123,4 +123,7 @@
   <metadata name="AnimationTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>186, 17</value>
   </metadata>
+  <metadata name="PathfinderTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>325, 17</value>
+  </metadata>
 </root>

--- a/ZionEscape/NPC.h
+++ b/ZionEscape/NPC.h
@@ -43,7 +43,7 @@ public:
     return Point(deltaX, deltaY);
   }
 
-  void Move(int deltaX, int deltaY) override {
+  void Move(int deltaX, int deltaY, Grid^ grid) override {
     if (path == nullptr || !(path->Count > 0)) {
       StopAnimation();
       return;
@@ -57,9 +57,10 @@ public:
       drawingArea.Y += deltaY < 0 ? -velocity : velocity;
 
 
-    Point currentWaypoint = path[path->Count - 1]->worldPos;
+    Node^ currentWaypoint = path[path->Count - 1];
+    Node^ currentNode = grid->GetNodeFromWorldPoint(drawingArea.Location);
 
-    if (drawingArea.Location == currentWaypoint) {
+    if (currentNode->Equals(currentWaypoint)) {
       path->Remove(path[path->Count - 1]);
     }
 

--- a/ZionEscape/Player.h
+++ b/ZionEscape/Player.h
@@ -61,7 +61,6 @@ public:
     if (!keysPressed->Contains(e->KeyCode)) {
       keysPressed->Add(e->KeyCode);
       StartAnimation();
-      // ResetPathfinders();
     }
   }
 


### PR DESCRIPTION
### Qué es lo que hace

- Se arregló la creación de caminos con un _timer_ independiente.
- Se permitió que el _Pathfinder_ solo sea buscado para una Entidad si es que no está en alguno de los nodos cerca del su _target_.

### Por qué es necesario

El `Pathfinder` estuvo roto desde el inicio, pero nunca fue corregido _hasta ahora_.
